### PR TITLE
docs: v15 step 24K + ALB-122 trueno PTX fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ A **350M-parameter decoder-only transformer** for Python code completion, traine
 
 ## Current Status
 
-**v15 training RUNNING** (March 22, 2026) — Phase change confirmed at step 3K.
+**v15 training RUNNING** — Step 24K/155K (15.6%), 786M tokens processed.
 
 | Metric | Value |
 |--------|-------|
 | Training run | v15 (15th attempt, seed=123) |
-| Step | 5,000 / 155,000 (3.2%) |
-| Best val_ppl | **333** (step 5K) |
-| Throughput | 8,500 tok/s, 24.6% MFU |
+| Step | 24,000 / 155,000 (15.6%) |
+| Best val_ppl | **309** (step 9K, pre-outage) |
+| Throughput | 14,900 tok/s, 46.9% MFU |
 | Hardware | RTX 4090 (24 GB), single GPU |
 | Data | codeparrot-clean, 5.08B tokens (73% Chinchilla) |
-| ETA | ~5 days from launch |
+| ETA | ~3.3 days remaining |
 
-**v15 is the strongest early convergence of any run** — 21% ahead of the previous best (v13) at step 5K. Phase change occurred at step 3K (v13 at 4K, v9 at 4.75K).
+Phase change at step 3K (earliest ever). Power outage at step 11K — resumed from step 10K checkpoint. Post-resume best: 400 (step 17K). 98 gaps fixed including ALB-122 (trueno PTX bug discovered during resume).
 
 ### What We've Built
 

--- a/docs/book/src/spec/06-training.md
+++ b/docs/book/src/spec/06-training.md
@@ -234,24 +234,21 @@ At `seq_len=2048, batch=8`: OOM at block 21 upload.
 | distill-v3 (v9 + 58M mixed tokens) | 2,400 | —→— | ~40min | **STOPPED** — val_ppl=658. HumanEval 0% pass@1. Insufficient tokens + raw code format. |
 | 350M v13 (from scratch, full epoch, 5.08B tokens) | 62K / 155K | 10.40→6.87 | 40.1h | **STOPPED** (patience=30) — Best val_ppl=**239** at step 32K (inflated by 2x data overlap). System reboot at step 25671 caused data loader restart → 2x overlap on shards 1-4 → val_ppl collapse at step 50K when model hit new data. gnorm collapsed 0.08→0.01. |
 | 350M v14 (from scratch, ALB-120 fixed) | 20K / 155K | 10.40→6.66 | 12h | **KILLED** (plateau) — val_ppl stuck at ~782 for 19K steps. No phase change. Degenerate init with seed=42 on recompiled binary. |
-| 350M v15 (from scratch, seed=123) | 155K target | 10.37→5.81 | ~5.3 days | **RUNNING** — phase change at step 3K! val_ppl 805→538→362→333. 21% ahead of v13 at step 5K. Strongest early convergence yet. |
+| 350M v15 (from scratch, seed=123) | 155K target | 10.37→5.58 | ~5.3 days | **RUNNING** — step 24K (15.6%). Phase change at step 3K. Best pre-outage: 309 (step 9K). Power outage at step 11K → resumed from 10K (ALB-120). Post-resume best: 400 (step 17K). ALB-122 (trueno PTX bug) discovered+fixed during resume. |
 
-**v14 early convergence** (should match v13 pre-reboot trajectory):
+**v15 convergence tracking** (seed=123, strongest early convergence):
 
-| Step | v13 val_ppl | v14 val_ppl | v14 note |
+| Step | v13 val_ppl | v15 val_ppl | v15 note |
 |------|-----------|-----------|----------|
-| 1000 | 800 | 838 | mid-warmup |
-| 2000 | 829 | **571** | v14 31% better at warmup end |
-| 3000 | 812 | 856 | plateau — both similar |
-| 4000 | **499** | 803 | v13 phase-changed here; v14 hasn't yet |
-| 5000 | 426 | 789 | v14 still in plateau. Checkpoint saved. |
-| 6000 | 455 | 796 | v14 still no phase change. v13 was at 455 (post-phase-change). |
-| 7000 | 655 | 795 | v14 plateau continues. |
-| 8000 | 414 | 783 | v14 plateau (best so far: 783). v13 was at 414. |
-| 9000 | 366 | 786 | v14 plateau. v13 was at 366. |
-| 10000 | 328 | 805 | v14 plateau continues. v13 was at 328. |
-| 15000 | 472 | 786 | v14 still flat. gnorm collapsed to 0.025. |
-| 19000 | 317 | 782 | **v14 KILLED** — 19 evals at ~782. Degenerate init. v15 launched with seed=123. |
+| 3000 | 812 | **538** | **Phase change** — earliest ever |
+| 4000 | 499 | **362** | Accelerating |
+| 5000 | 426 | **333** | Best pre-outage. 21% ahead of v13. Checkpoint saved. |
+| 9000 | 366 | **309** | **Best overall**. Pre-outage. |
+| 10000 | 328 | 912 | Spike (pre-outage). |
+| 11000 | 355 | 378/499 | Pre-outage 378. **POWER OUTAGE** → resumed from 10K. Post-resume 499. |
+| 17000 | 717 | **400** | Best post-resume. Fresh GPU optimizer recovering. |
+| 18000 | 373 | 1736 | **Severe spike** (worst ever). |
+| 24000 | 407 | **415** | Recovery continuing. Predictor slope turned positive (0.08). |
 
 **v9 vs v13 convergence comparison** (first 5000 steps):
 

--- a/docs/book/src/spec/11-gaps.md
+++ b/docs/book/src/spec/11-gaps.md
@@ -204,7 +204,7 @@ wired into `apr` → dogfooded in albor pipeline → FALSIFY/pmat verified → c
 | v12 | 37 | 1.2M | 5639 | KILLED | ALB-118: resume loaded embed optimizer only, full-LR step destroyed weights |
 | v13 | 62K/155K (40%) | 2.03B/5.08B | **239** (step 32K, inflated) | **STOPPED** (patience=30) | System reboot → data loader restart → 2x data overlap. val_ppl collapsed from 239 to 782 at step 50K when model hit new data. gnorm collapsed 0.08→0.01. Best checkpoint may be overfit. |
 | v14 | 20K/155K | 655M/5.08B | 571 (step 2K) | KILLED (plateau) | val_ppl stuck at ~782 for 19K steps. Degenerate init with seed=42 on recompiled binary. No phase change. |
-| v15 | 11K/155K (7.1%) | 360M/5.08B | **309** (step 9K) | **RUNNING** | seed=123. Phase change at step 3K. Resumed from step 10K after power outage (ALB-120 skip active). ALB-122 (trueno PTX bug) discovered and fixed during resume. |
+| v15 | 24K/155K (15.6%) | 786M/5.08B | **309** (step 9K pre-outage) | **RUNNING** | seed=123. Phase change at step 3K. Power outage at step 11K → resumed from 10K. Post-resume best: 400 (step 17K). ALB-122 fixed. 14.9K tok/s / 46.9% MFU post-reboot. |
 | distill-v3 | 2400 | 58M (mixed) | 658 | STOPPED | 0% HumanEval — insufficient tokens + raw code format |
 
 *Gaps are added as they are discovered during implementation and dogfooding.*

--- a/docs/book/src/spec/17-success.md
+++ b/docs/book/src/spec/17-success.md
@@ -34,9 +34,9 @@
 | v12 | 37 | 5,639 | — | — | **KILLED**: ALB-118 — only CPU embed optimizer restored |
 | v13 | 62,000 | 239 (inflated) | 8,400 | 26.4% | **STOPPED** (patience=30) — 2x data overlap from reboot. See §6 post-mortem. |
 | v14 | 20,000 | 571 | 8,190 | 23.7% | **KILLED** (plateau) — val_ppl stuck at ~782 for 19K steps. Degenerate init (seed=42). |
-| **v15** | **5,000+** | **333** | **8,500** | **24.6%** | **RUNNING** — phase change at step 3K! val_ppl 805→538→362→333. 21% ahead of v13. seed=123. |
+| **v15** | **24,000+** | **309** | **14,900** | **46.9%** | **RUNNING** — step 24K (15.6%). Best: 309 (step 9K pre-outage). Power outage at step 11K, resumed from 10K. Post-resume best: 400 (step 17K). Oscillating 400-657. |
 
-**v15 training (ACTIVE):** From scratch with seed=123, full epoch. **Phase change at step 3K** — earliest and strongest of any run. val_ppl trajectory: 805→793→538→362→333. At step 5K, v15 is 21% ahead of v13 (333 vs 426) and 2.4x ahead of where v14 was (333 vs 789). Predictor slope 0.60, predicting val_ppl≈45 at step 155K. ALB-120 fix active. If convergence continues at this rate, v15 should surpass v9's best (ppl=129) by step 10K-15K and could reach sub-50 by step 155K.
+**v15 training (ACTIVE):** From scratch with seed=123. Phase change at step 3K (earliest ever). Best pre-outage val_ppl=309 (step 9K). Power outage at step 11,129 → resumed from step 10K checkpoint (ALB-120 batch skip). Post-resume recovery in progress: GPU optimizer moments are fresh, val_ppl oscillating 400-657 (best post-resume: 400 at step 17K). Throughput increased to 14.9K tok/s / 46.9% MFU post-reboot. ALB-122 (trueno PTX MulWide bug) discovered and fixed during resume. Step 24K predictor slope turned positive (0.08) — convergence resuming.
 
 ### Good (Phase 5 complete)
 - [x] Distillation from Qwen3-Coder-30B demonstrated (ALB-010); text-based synthetic data pipeline

--- a/docs/book/src/spec/19-training-performance.md
+++ b/docs/book/src/spec/19-training-performance.md
@@ -42,18 +42,16 @@ reverse.
 |--------|-------|--------|
 | Throughput (pre-optimization) | **934 tok/s** | 350M, seq=1024, batch=4, RTX 4090 |
 | Step time (pre-optimization) | ~4.4s | Same config |
-| **Throughput (v15, current)** | **8,500 tok/s** | Same config (step 5K, seed=123) |
-| **Step time (v15, current)** | **~440 ms** | Same config (per micro-batch) |
-| **MFU (v15, current)** | **24.6%** | vs TF32 tensor core peak |
-| VRAM usage | ~13.1 GB / 24 GB | Same config (includes GPU optimizer state) |
-| Training loss (v15, step 5K) | **5.81** | v15 run — phase change confirmed, converging |
-| Best val_ppl (v15) | **333** | step 5K — 21% ahead of v13 at same step (426) |
-| Loss trajectory (v15) | 10.37 → 5.81 (step 5K) | v15 run (155K target, 3.2% complete) |
-| Gradient norm (v15) | gnorm=0.20-0.50 | Healthy, strong gradients |
-| Tokens processed (v15, step 5K) | **164M** | 5,000 × 4 × 8 × 1024 |
-| **Previous best** (v9) | 4.86 (step 14.9K, 490M tok) | val_ppl=129 — v15 on track to surpass at step 10-15K |
-| v14 (killed) | 6.66 (step 20K, 655M tok) | KILLED — val_ppl stuck at ~782. Degenerate seed |
-| v13 (stopped) | 6.87 (step 62K, 2.03B tok) | STOPPED — val_ppl=239 (inflated by data overlap) |
+| **Throughput (v15, post-reboot)** | **14,900 tok/s** | Post-reboot improvement (was 8,500 pre-outage) |
+| **Step time (v15, current)** | **~445 ms** | Same config (per micro-batch) |
+| **MFU (v15, post-reboot)** | **46.9%** | vs TF32 tensor core peak (up from 24.6%) |
+| VRAM usage | ~13.4 GB / 24 GB | Same config (includes GPU optimizer state) |
+| Training loss (v15, step 24K) | **5.58** | Recovering from power outage resume |
+| Best val_ppl (v15) | **309** | step 9K (pre-outage). Post-resume best: 400 (step 17K). |
+| Loss trajectory (v15) | 10.37 → 5.58 (step 24K) | 15.6% complete, 786M tokens |
+| Gradient norm (v15) | gnorm=0.09 | Healthy, stable |
+| Tokens processed (v15, step 24K) | **786M** | 24,000 × 4 × 8 × 1024 |
+| **Previous best** (v9) | 4.86 (step 14.9K, 490M tok) | val_ppl=129 — still best genuine result |
 
 ### 1.2 MFU Analysis
 


### PR DESCRIPTION
## Summary
- Add ALB-122 to gap register (trueno PtxOp::MulWide fix, trueno@63a976ff)
- Update v15 training state: step 24K, best 309 (pre-outage), post-resume recovering
- Update §6, §11, §17, §19, README with current metrics
- 14.9K tok/s / 46.9% MFU post-reboot (up from 8.5K/24.6%)

## Test plan
- [x] All spec sections consistent
- [x] 98 gaps fixed, 9 open

🤖 Generated with [Claude Code](https://claude.com/claude-code)